### PR TITLE
:memo: Fixes the LICENSE link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ commands in the project root directory:
 
 ## License
 
-[AGPL-v2.0](LICENSE.md)
+[AGPL-v2.0](LICENSE)


### PR DESCRIPTION
### Description of the Change

Changes the link of the license in README to actually link to the LICENSE file at repository root.
