### PR TITLE
Add Multilingual support to Moore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,7 @@ system administrator](mailto:admin@utn.se). He will help you get started.
     * :art: `:art:` when improving templates
     * :racehorse: `:racehorse:` when improving performance
     * :memo: `:memo:` when writing docs
+    * :speech_balloon: `:speech_balloon:` when writing translations
     * :bug: `:bug:` when fixing a bug
     * :fire: `:fire:` when removing code or files
     * :green_heart: `:green_heart:` when fixing for CI builds

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ regarding Project Moore's code base is located within the code. Like the rest
 of the UTN infrastructure, a global overview of the application is documented
 on [docs.utn.se](https://docs.utn.se/)
 
-
 ## Testing
 
 All code in this repository is tested in two ways: we use [Django test
@@ -50,6 +49,23 @@ commands in the project root directory:
 
 - `./website/manage.py test` - to test with our Django test suites
 - `flake8 website` - to run the flake8 style enforcer
+
+## Translating
+
+Project Moore intends to be multilingual. The web application is available in
+both Swedish and English. Whenever any translatable text is added or changed it
+should be translated using translation files.
+
+*Within Project Moore we use American English.*
+
+To create translations for an app:
+
+1. `cd website/<appname>`
+1. `../manage.py makemessages`
+2. This will create or update the files under `website/<appname>/locale/`.
+3. Use poedit (or your favourite tool -- please do not use a plain text editor
+since those cannot handle all the subtleties) to fix the translations.
+4. `../manage.py compilemessages`
 
 ## License
 

--- a/website/website/locale/sv/LC_MESSAGES/django.po
+++ b/website/website/locale/sv/LC_MESSAGES/django.po
@@ -1,0 +1,22 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-02 12:08+0100\n"
+"PO-Revision-Date: 2017-02-02 12:20+0100\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Last-Translator: Jip J. Dekker <jip@dekker.li>\n"
+"Language-Team: \n"
+"X-Generator: Poedit 1.8.11\n"
+
+#: settings/base.py:114
+msgid "English"
+msgstr "Engelska"
+
+#: settings/base.py:115
+msgid "Swedish"
+msgstr "Svenska"

--- a/website/website/settings/base.py
+++ b/website/website/settings/base.py
@@ -40,6 +40,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
 ]
 
 ROOT_URLCONF = 'website.urls'

--- a/website/website/settings/base.py
+++ b/website/website/settings/base.py
@@ -115,6 +115,8 @@ LANGUAGES = [
     ('sv', _('Swedish'))
 ]
 
+LOCALE_PATHS = ['locale']
+
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/

--- a/website/website/settings/base.py
+++ b/website/website/settings/base.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 
 import os
 
+from django.utils.translation import ugettext_lazy as _
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -100,7 +102,7 @@ PASSWORD_HASHERS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Europe/Stockholm'
 
 USE_I18N = True
 

--- a/website/website/settings/base.py
+++ b/website/website/settings/base.py
@@ -100,7 +100,7 @@ PASSWORD_HASHERS = [
 # Internationalization
 # https://docs.djangoproject.com/en/1.10/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'en'
 
 TIME_ZONE = 'Europe/Stockholm'
 
@@ -109,6 +109,11 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
+
+LANGUAGES = [
+    ('en', _('English')),
+    ('sv', _('Swedish'))
+]
 
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
### Description of the Change

This pull request enables the default i18n functionality of Django. We can use this to support both English and Swedish in the new website.

### Alternate Designs

- A custom solution?

<!-- Explain what other alternates were considered and why the proposed version
was selected -->

### Benefits

- Multilingual support (requirement!)

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

- It makes some things harder
- Might not be supported by all extension out there

<!-- What are the possible side-effects or negative impacts of the code change? -->
