### PR TITLE
:fire: Disable Django Admin

### DIFF
--- a/website/website/settings/base.py
+++ b/website/website/settings/base.py
@@ -51,7 +51,7 @@ INSTALLED_APPS = [
     'compressor',
     'rules.apps.AutodiscoverRulesConfig',
 
-    'django.contrib.admin',
+    'django.contrib.admin',  # Used for wagtail admin filters
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',

--- a/website/website/urls.py
+++ b/website/website/urls.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 from django.conf.urls import include, url
-from django.contrib import admin
 
 from search import views as search_views
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
@@ -10,9 +9,6 @@ from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 
 urlpatterns = [
-    # TODO: Disable django admin
-    url(r'^django-admin/', include(admin.site.urls)),
-
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
 


### PR DESCRIPTION
We use Wagtail admin instead. It helps to combine everything.