### PR TITLE
Fix naming of positions between years

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Translate person number label where applicable
 - Empty height of the organisational menu now matches the filled height.
 - Initial selection of study is maintained when on section selection.
+- Naming of position with double years if the span is over two years.
 
 ## [0.1.2] - 2017-04-01
 ### Added

--- a/website/involvement/models.py
+++ b/website/involvement/models.py
@@ -340,7 +340,11 @@ class Position(models.Model):
     comment = TranslatedField('comment_en', 'comment_sv')
 
     def __str__(self) -> str:
-        return "{} {}".format(self.role.name, self.term_from.year)
+        if self.term_from.year != self.term_to.year:
+            return "%s %s-%s"\
+                   % (self.role.name, self.term_from.year, self.term_to.year)
+        else:
+            return "%s %s" % (self.role.name, self.term_from.year)
 
     @property
     def is_past_due(self):


### PR DESCRIPTION
### Description of the Change

Naming of a position is now influenced by both from and until when in the term.