### PR TITLE
Materialize CSS mistakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Position names are now contained by their container in the overview.
+- The language and login buttons are now on the same height.
+- The default team logo in the position view is now the actual UTN logo.
+- Materialized fields no longer contain colons.
 
 ## [0.3.1] - 2017-04-27
 ### Fixed

--- a/website/involvement/templates/involvement/open_positions.html
+++ b/website/involvement/templates/involvement/open_positions.html
@@ -11,7 +11,7 @@
                 <div class="collapsible-header">
                     {% if pos.role.team.logo %}{% image pos.role.team.logo fill-45x45 as logo %}{% endif %}
                     <img class="circle" src="{% if logo %}{{ logo.url }}{% else %}{% static 'images/bocken.svg' %}{% endif %}">
-                    <div class="header-text">
+                    <div class="header-text row">
                         <h3>{{ pos }}</h3>
                         <div class="team">
                             {% if pos.role.team %}

--- a/website/involvement/templates/involvement/position.html
+++ b/website/involvement/templates/involvement/position.html
@@ -22,7 +22,7 @@
                 <div class="card">
                     <div class="card-image">
                         {% if position.role.team.logo %}{% image position.role.team.logo original as logo %}{% endif %}
-                        <img src="{% if logo %}{{ logo.url }}{% else %}{% static 'images/bocken.svg' %}{% endif %}">
+                        <img src="{% if logo %}{{ logo.url }}{% else %}{% static 'images/logo.svg' %}{% endif %}">
                     </div>
                     <div class="card-content">
                         {% if position.role.team %}

--- a/website/materialize/templatetags/materialize.py
+++ b/website/materialize/templatetags/materialize.py
@@ -9,6 +9,7 @@ def get_widget_name(field):
 
 
 def append_classes(field):
+    field.field.label_suffix = ''
     classes = field.field.widget.attrs.get('class', '')
     classes += ' validate'
     if field.errors:

--- a/website/website/static/sass/partials/_involvement.scss
+++ b/website/website/static/sass/partials/_involvement.scss
@@ -17,7 +17,6 @@
         height: 30px;
         line-height: 30px;
         padding: 0 1.5rem;
-
       }
       .hide-on-med-and-up {
         height: 10px;
@@ -27,17 +26,25 @@
     .header-text {
       float: left;
       line-height: 0;
+      margin-left: 5px;
+      width: calc(100% - 220px);
       h3 {
+        @extend .truncate;
         line-height: 0.8;
       }
       .team {
-        margin-left: 0px;
+        margin-left: 0;
         i {
           height: 14px;
           font-size: 20px;
           margin-right: 5px;
           line-height: 0;
         }
+      }
+    }
+    @media #{$small-and-down} {
+      .header-text {
+        width: calc(100% - 150px);
       }
     }
   }

--- a/website/website/static/sass/partials/_navigation.scss
+++ b/website/website/static/sass/partials/_navigation.scss
@@ -21,6 +21,10 @@ $logo-fallback-margin-top:  - ($logo-height + 10px);
   line-height: $line-height;
   padding: $navigation-padding 0;
 
+  ul button.btn {
+    margin-top: -2px; // To match a .btn
+  }
+
   .dropdown-content {
     width: auto !important;
   }


### PR DESCRIPTION
### Description of the Change

This PR contains fixes for several CSS mistakes made in the switch to Materialize:
- Position names are now contained by their container in the overview.
- The language and login buttons are now on the same height.
- The default team logo in the position view is now the actual UTN logo.
- Materialized fields no longer contain colons.


<!--Please select the appropriate "topic category"/blue label -->