### PR TITLE
Truncate the team name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Truncate the team name when screen gets too small
 
 ## [0.3.4] - 2017-05-03
 ### Fixed

--- a/website/website/static/sass/partials/_involvement.scss
+++ b/website/website/static/sass/partials/_involvement.scss
@@ -25,20 +25,21 @@
 
     .header-text {
       float: left;
-      line-height: 0;
+      line-height: 1;
       margin-left: 5px;
       width: calc(100% - 220px);
       h3 {
         @extend .truncate;
-        line-height: 0.8;
+        margin: 0.8rem 0 0 0;
       }
       .team {
         margin-left: 0;
+        @extend .truncate;
         i {
           height: 14px;
           font-size: 20px;
           margin-right: 5px;
-          line-height: 0;
+          line-height: 0.6;
         }
       }
     }


### PR DESCRIPTION
### Description of the Change

This PR truncates the team name on the open positions page when the screen gets too small.


<!--Please select the appropriate "topic category"/blue label -->