### PR TITLE
Fix double truncation of team name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Truncate the team name when screen gets too small.
 - Use actual logo as default within the my applications page.
+- Fix the double truncation of team names in the open positions page.
 
 ## [0.3.4] - 2017-05-03
 ### Fixed

--- a/website/involvement/templates/involvement/open_positions.html
+++ b/website/involvement/templates/involvement/open_positions.html
@@ -15,7 +15,7 @@
                         <h3>{{ pos }}</h3>
                         <div class="team">
                             {% if pos.role.team %}
-                                <i class="material-icons">group</i>{{ pos.role.team|truncatechars:20 }}
+                                <i class="material-icons">group</i>{{ pos.role.team }}
                             {% else %}
                                 <i class="material-icons">person</i>{% trans 'unaffiliated'|capfirst %}
                             {% endif %}


### PR DESCRIPTION
### Description of the Change

Fix the double truncation of team names in the open positions page.

<!--Please select the appropriate "topic category"/blue label -->