### PR TITLE
Use short dates for the positions overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Do not show the error video on logout
 - Fit the last apply button within the collapsible header
+- Use short dates on involvement open positions page.
 
 ## [0.4.0]
 ### Added

--- a/website/involvement/templates/involvement/open_positions.html
+++ b/website/involvement/templates/involvement/open_positions.html
@@ -24,7 +24,7 @@
                     <div class="apply right">
                         <div class="hide-on-med-and-up"></div>
                         <a class="btn" href="{% routablepageurl page 'position' pos.id  %}">{% trans 'apply' %}</a><br>
-                        <div class="hide-on-small-only"><b style="color: {{ pos.recruitment_end|date_color }};">{% trans 'deadline'|capfirst %}: {{ pos.recruitment_end }}</b></div>
+                        <div class="hide-on-small-only"><b style="color: {{ pos.recruitment_end|date_color }};">{% trans 'deadline'|capfirst %}: {{ pos.recruitment_end|date:"SHORT_DATE_FORMAT"  }}</b></div>
                     </div>
                 </div>
                 <div class="collapsible-body">


### PR DESCRIPTION
### Description of the Change

Use short dates for the positions overview to avoid the CSS struggle with the dynamic widths.

### Applicable Issues

<!-- Enter any applicable issues here -->


<!--Please select the appropriate "topic category"/blue label -->