### PR TITLE
Allow drafted applications to be appointed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Do not show the error video on logout
 - Fit the last apply button within the collapsible header
 - Use short dates on involvement open positions page.
+- Allow users that drafted an application to be appointed using overturn field.
 
 ## [0.4.0]
 ### Added

--- a/website/involvement/forms.py
+++ b/website/involvement/forms.py
@@ -107,6 +107,8 @@ class AppointmentForm(forms.Form):
                     )
                 elif self.position.applications.filter(
                     applicant__username=u
+                ).exclude(
+                    status='draft'
                 ).exists():
                     raise forms.ValidationError(
                         _('User %(user)s already applied for this position '
@@ -144,8 +146,11 @@ class AppointmentForm(forms.Form):
             user = get_user_model().objects.get(
                     username=user
             )
-            Application.objects.create(
+            appl, created = Application.objects.get_or_create(
                 position=self.position,
                 applicant=user,
-                status='appointed',
+                defaults={'status': 'appointed'}
             )
+            if not created:
+                appl.status = 'appointed'
+                appl.save()


### PR DESCRIPTION
### Description of the Change

Add a check to the overturning field to see if a draft by the user was already created. If so, than this draft will be used.

### Applicable Issues

- Fixes #117 

<!--Please select the appropriate "topic category"/blue label -->