### PR TITLE
Fix access to the Swedish banner text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixes access to the Swedish HomePage banner text
 
 ## [0.5.0]
 ### Added

--- a/website/home/models.py
+++ b/website/home/models.py
@@ -121,7 +121,7 @@ class Banner(Orderable):
             FieldPanel('title_sv'),
         ]),
         FieldPanel('text_en'),
-        FieldPanel('text_en'),
+        FieldPanel('text_sv'),
         FieldPanel('link'),
         FieldRowPanel([
             FieldPanel('button_en'),


### PR DESCRIPTION
### Description of the Change

Fixes a typo that hid the Swedish banner text from the admin editing windows.

### Applicable Issues

- Fixes #143 
- Fixes #141 


<!--Please select the appropriate "topic category"/blue label -->