### PR TITLE
Fix the ordering of the Google Form Index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Customizable site-specific footers
 ### Fixed
 - Translation of sub-menus
+- Ordering of the Google Form Index (This is now reverse order of the deadline)
 
 ## [0.5.1]
 ### Added

--- a/website/google/models.py
+++ b/website/google/models.py
@@ -51,7 +51,8 @@ class GoogleFormIndex(Page):
         context = super(GoogleFormIndex, self).get_context(request, **kwargs)
 
         # Add extra variables and return the updated context
-        context['google_forms'] = GoogleFormPage.objects.child_of(self).live()
+        context['google_forms'] = GoogleFormPage.objects.child_of(self).live()\
+            .order_by('-deadline')
         return context
 
 


### PR DESCRIPTION
### Description of the Change

An order is now enforced on the Google Form pages located under the index. The entries are sorted reverse order of their deadline.


<!--Please select the appropriate "topic category"/blue label -->