### PR TITLE
Hide old applications from the position inspect window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Old non-appointed applications are now hidden from the position inspection view
 ### Fixed
 - Release tag for Sentry logging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Cron task to delete old non-appointed applications. (2 years after recruitment ends)
 ### Changed
 - Old non-appointed applications are now hidden from the position inspection view
 ### Fixed

--- a/website/involvement/cron.py
+++ b/website/involvement/cron.py
@@ -67,3 +67,15 @@ def send_extension_emails():
             subject, body, None, [pos.role.election_email]
         )
         email_message.send()
+
+
+@kronos.register('0 3 * * *')  # At 03:00.
+def remove_old_applications():
+    old_applications = Application.objects.filter(
+        position__recruitment_end__lte=date.today() - timedelta(days=730)
+    ).exclude(
+        status='appointed'
+    )
+
+    for app in old_applications:
+        app.delete()

--- a/website/involvement/templates/modeladmin/involvement/position/inspect.html
+++ b/website/involvement/templates/modeladmin/involvement/position/inspect.html
@@ -9,7 +9,7 @@
         <dt>{% trans 'applications' %}</dt>
         <dd>
             <ul>
-                {% for a in instance.applications.all %}
+                {% for a in applicants %}
                     <li>
                         {% if a.status == 'draft' %}
                             <i>{{ a.get_status_display }}:</i>

--- a/website/involvement/views.py
+++ b/website/involvement/views.py
@@ -296,6 +296,19 @@ class PositionEditView(EditView):
         return form
 
 
+class PositionInspectView(InspectView):
+    def get_context_data(self, **kwargs):
+        context = super(PositionInspectView, self).get_context_data(**kwargs)
+        applicants = self.instance.applications.all()
+        if self.instance.current_action() == 'done':
+            context['applicants'] = applicants.filter(status='appointed')
+        else:
+            context['applicants'] = applicants.exclude(
+                status__in=['disapproved', 'turned_down']
+            )
+        return context
+
+
 class RoleCreateView(CreateView):
     def get_form(self, form_class=None):
         form = super(RoleCreateView, self).get_form(form_class=form_class)

--- a/website/involvement/wagtail_hooks.py
+++ b/website/involvement/wagtail_hooks.py
@@ -13,8 +13,7 @@ from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup, \
 from involvement.models import Team, Role, Position, Application, \
     official_of, member_of
 from involvement.rules import is_admin, approve_state, appoint_state
-from involvement.views import RoleCreateView, RoleEditView, PositionCreateView, \
-    PositionEditView
+from involvement import views
 from utils.permissions import RulesPermissionHelper
 
 
@@ -52,8 +51,8 @@ class RoleAdmin(ModelAdmin):
     # https://code.djangoproject.com/ticket/8851#no1
     list_filter = ('team', 'archived')
     permission_helper_class = RulesPermissionHelper
-    create_view_class = RoleCreateView
-    edit_view_class = RoleEditView
+    create_view_class = views.RoleCreateView
+    edit_view_class = views.RoleEditView
 
     def get_queryset(self, request):
         if is_admin(request.user):
@@ -194,8 +193,9 @@ class PositionAdmin(ModelAdmin):
     inspect_view_enabled = True
     permission_helper_class = PositionPermissionHelper
     button_helper_class = PositionButtonHelper
-    create_view_class = PositionCreateView
-    edit_view_class = PositionEditView
+    create_view_class = views.PositionCreateView
+    edit_view_class = views.PositionEditView
+    inspect_view_class = views.PositionInspectView
 
     def get_queryset(self, request):
         if is_admin(request.user):


### PR DESCRIPTION
### Description of the Change

This PR hides old applications that have been submitted, but not appointed, from the inspect window of old positions. For new positions, applications are hidden whenever they are disapproved or turned down.

This PR also adds a cron task to remove these applications after 2 years.

### Applicable Issues

- Closes #158 


<!--Please select the appropriate "topic category"/blue label -->