### PR TITLE
Remove ADMINS from production settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Old non-appointed applications are now hidden from the position inspection view
 - All blocks in StreamFields have added to groups
+- Production errors are no longer sent to the admin e-mails. (This was double with Sentry)
 ### Fixed
 - Release tag for Sentry logging
 

--- a/website/website/settings/production.py
+++ b/website/website/settings/production.py
@@ -52,9 +52,7 @@ DEFAULT_FROM_EMAIL = 'info@utn.se'
 
 EMAIL_SUBJECT_PREFIX = '[UTN] '
 
-# Admins - will be sent error messages
-ADMINS = [('UTN System Administrator', 'admin@utn.se')]
-
+# Sentry Configuration - will be sent error messages
 RAVEN_CONFIG = {
     'dsn': os.environ.get('SENTRY_DSN'),
     'release': raven.fetch_git_sha(os.path.dirname(BASE_DIR)),


### PR DESCRIPTION
### Description of the Change

This PR removes `ADMINS` from the production settings to stop duplicate e-mails from arriving.

<!--Please select the appropriate "topic category"/blue label -->