### PR TITLE
Super user panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- A panel in the Admin home showing all super users
 ### Fixed
 - Variable height of the responsive image block
 

--- a/src/members/models.py
+++ b/src/members/models.py
@@ -191,7 +191,7 @@ class Member(SimpleEmailConfirmationUserMixin, AbstractUser):
 
     def __str__(self) -> str:
         if self.first_name and self.last_name:
-            return '%s %s' % (self.first_name, self.last_name)
+            return self.get_full_name()
         else:
             return self.username
 

--- a/src/members/signals.py
+++ b/src/members/signals.py
@@ -12,7 +12,7 @@ from members.models import Member
 
 @receiver(unconfirmed_email_created, dispatch_uid='send_email_confirmation')
 def send_confirmation_email(sender, email, user=None, **kwargs):
-    user = user or sender
+    user = user or sender  # TODO: use user.send_email
     if user is not None:
         context = {
             'email': email,

--- a/src/members/templates/members/admin_panel.html
+++ b/src/members/templates/members/admin_panel.html
@@ -1,0 +1,30 @@
+{% load i18n %}
+<div class="panel nice-padding">
+    <section>
+        <h2>{% trans 'system administrators'|title %}</h2>
+    </section>
+    <table class="listing listing-page">
+        <colgroup>
+            <col>
+            <col width="20%">
+            <col width="20%">
+        </colgroup>
+        <thead>
+            <tr>
+                <th class="title">{% trans 'name'|title %}</th>
+                <th>{% trans 'email'|title %}</th>
+                <th>{% trans 'phone number'|title %}</th>
+            </tr>
+        </thead>
+    <tbody>
+        {% for s in supers %}
+            <tr>
+                <td>{% if user.is_superuser %}<a href="{% url 'wagtailusers_users:edit' s.id %}">{{ s }}</a>{% else %}{{ s }}{% endif %}</td>
+                <td><a href="mailto:{{ s.get_primary_email }}">{{ s.get_primary_email }}</a></td>
+                <td>{{ s.phone_number }}</td>
+            </tr>
+        {% endfor %}
+
+    </tbody>
+    </table>
+</div>

--- a/src/members/wagtail_hooks.py
+++ b/src/members/wagtail_hooks.py
@@ -1,12 +1,14 @@
 from django.forms import CheckboxSelectMultiple
+from django.template import loader
+from django.utils.translation import ugettext_lazy as _
 from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup, \
     modeladmin_register
 from wagtail.contrib.modeladmin.views import EditView, CreateView
 from wagtail.wagtailadmin.edit_handlers import TabbedInterface, ObjectList, \
     FieldPanel
+from wagtail.wagtailcore import hooks
 
-from members.models import StudyProgram, Section
-from django.utils.translation import ugettext_lazy as _
+from members.models import StudyProgram, Section, Member
 
 
 class StudyProgramEditHandler:
@@ -90,3 +92,22 @@ class EducationAdminGroup(ModelAdminGroup):
 
 
 modeladmin_register(EducationAdminGroup)
+
+
+class SuperUserPanel(object):
+    order = 1000
+
+    def __init__(self, request):
+        self.request = request
+
+    def render(self):
+        c = {
+            'supers': Member.objects.filter(is_superuser=True),
+            'user': self.request.user
+        }
+        return loader.get_template('members/admin_panel.html').render(c)
+
+
+@hooks.register('construct_homepage_panels')
+def add_super_user_panel(request, panels):
+    return panels.append(SuperUserPanel(request))

--- a/src/moore/templates/wagtailadmin/home.html
+++ b/src/moore/templates/wagtailadmin/home.html
@@ -1,4 +1,4 @@
 {% extends "wagtailadmin/home.html" %}
 {% load i18n %}
 
-{% block branding_welcome %}{% trans 'Welcome UTN website administrators!' %}{% endblock %}
+{% block branding_welcome %}{% trans 'Welcome UTN website editors!' %}{% endblock %}


### PR DESCRIPTION
### Description of the Change

This PR adds a panel showing all super users to the wagtail admin interface. This helps making sure that no old system administrators keep their permissions.

### Applicable Issues

- Closes #180 


<!--Please select the appropriate "topic category"/blue label -->