### PR TITLE
Changed font color to overlay and box size on involvement 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+Changed the font color on the overlay from #9E9E9E to #424242 
+
 ## [0.9.0] - 2017-07-27
 ### Added
 - Block to embed Google Calendar fields

--- a/src/moore/static/sass/partials/blocks/_overlay.scss
+++ b/src/moore/static/sass/partials/blocks/_overlay.scss
@@ -14,7 +14,7 @@
   }
 
   p {
-    color: #9E9E9E;
+    color: #424242;
     font-size: 18px;
     margin: 0 0 50px 0;
     padding: 0 100px;

--- a/src/moore/static/sass/partials/pages/_involvement.scss
+++ b/src/moore/static/sass/partials/pages/_involvement.scss
@@ -1,6 +1,6 @@
 .positions {
   .collapsible-header {
-    height: 60px;
+    height: 80px;
 
     img {
       float: left;


### PR DESCRIPTION
… fits

### Description of the Change

The font color is not good right now if you want colorful pictures in the background. And the box sizes on involvement doesn't fit the text. 

### Applicable Issues

<!-- Enter any applicable issues here -->


<!--Please select the appropriate "topic category"/blue label -->