### PR TITLE
Fix the ambiguous name error

### DIFF
--- a/src/home/models.py
+++ b/src/home/models.py
@@ -66,9 +66,9 @@ class ContactPage(Page):
 
             for group in groups:
                 group = group.strip()
-                l = contacts.get(group, [])
-                l.append(contact.value['person'])
-                contacts[group] = l
+                list = contacts.get(group, [])
+                list.append(contact.value['person'])
+                contacts[group] = list
 
         context = super(ContactPage, self).get_context(
             request, *args, **kwargs


### PR DESCRIPTION
### Description of the Change

Fix the ambiguous name, as found by the flake8 linter, in the context method of the contact page.

<!--Please select the appropriate "topic category"/blue label -->