### PR TITLE
Add caching and whitelisted branches to the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: python
 python:
   - "3.5"
   - "3.6"
+cache: pip
+branches:
+  only:
+  - master
+  - development
 install:
 - pip install -r dev-requirements.txt
 - pip install coveralls


### PR DESCRIPTION
### Description of the Change

Add caching and whitelisted branches to the Travis configuration. This should improve the time needed for a Travis build and reduce the number of builds.


<!--Please select the appropriate "topic category"/blue label -->