### PR TITLE
Correctly insert page introduction in forms (Fix #303)

### DIFF
--- a/src/home/templates/home/form_page.html
+++ b/src/home/templates/home/form_page.html
@@ -2,7 +2,7 @@
 {% load i18n materialize wagtailcore_tags %}
 
 {% block content %}
-    {% include_block page.intro_text %}
+    {% include_block page.intro %}
     <div class="container">
         <div class="card">
             <div class="card-content">


### PR DESCRIPTION
### Description of the Change

Fixed typo in form_page.html so that introductions show up

### Applicable Issues

Fixes #303 
