### PR TITLE
Raw html content type (fix #309)

### DIFF
--- a/src/home/models/web_page.py
+++ b/src/home/models/web_page.py
@@ -5,6 +5,7 @@ from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel, \
         TabbedInterface, ObjectList
 from wagtail.core.fields import StreamField
 from wagtail.core.models import Page
+from wagtail.core.blocks import RawHTMLBlock
 from blocks.models import WAGTAIL_STATIC_BLOCKTYPES
 from google.models import GoogleFormBlock, GoogleDriveBlock, \
     GoogleCalendarBlock
@@ -24,6 +25,7 @@ class WebPage(Page):
             ('google_drive', GoogleDriveBlock()),
             ('google_form', GoogleFormBlock()),
             ('news', LatestNewsBlock()),
+            ('html', RawHTMLBlock(group="Basic")),
         ],
         blank=True,
     )
@@ -33,6 +35,7 @@ class WebPage(Page):
             ('google_drive', GoogleDriveBlock()),
             ('google_form', GoogleFormBlock()),
             ('news', LatestNewsBlock()),
+            ('html', RawHTMLBlock(group="Basic")),
         ],
         blank=True,
     )

--- a/src/home/templates/home/form_page.html
+++ b/src/home/templates/home/form_page.html
@@ -2,7 +2,7 @@
 {% load i18n materialize wagtailcore_tags %}
 
 {% block content %}
-    {% include_block page.intro_text %}
+    {% include_block page.intro %}
     <div class="container">
         <div class="card">
             <div class="card-content">


### PR DESCRIPTION
### Description of the Change
Adds the standard RawHTMLBlock type to the basic web page type. Added under the group "Basic" block-types. 
<!-- We must be able to understand the design of your change from this description. -->

### Applicable Issues
Fix #309 
<!-- Enter any applicable issues here -->


<!--Please select the appropriate "topic category"/blue label -->