### PR TITLE
Refill cover letter and qualifications if reference form is invalid

### DIFF
--- a/src/involvement/templates/involvement/application_form.html
+++ b/src/involvement/templates/involvement/application_form.html
@@ -57,7 +57,7 @@
                 type="text"
                 {% if status == 'submitted' %} readonly {% endif %}
                 class="materialize-textarea validate{% if form.cover_letter.errors %} invalid{% endif %}">
-                {{ form.cover_letter.initial }}
+                {{ form.data.cover_letter|default:form.cover_letter.initial }}
             </textarea>
             <label for="{{ form.cover_letter.auto_id }}">{{ form.cover_letter.help_text }}</label>
             {% if form.cover_letter.errors %}{% include 'materialize/form/field_errors.html' %}{% endif %}
@@ -74,7 +74,7 @@
                 type="text"
                 {% if status == 'submitted' %} readonly {% endif %}
                 class="materialize-textarea validate{% if form.qualifications.errors %} invalid{% endif %}">
-                {{ form.qualifications.initial }}
+                {{ form.data.qualifications|default:form.qualifications.initial }}
             </textarea>
             <label for="{{ form.qualifications.auto_id }}">{{ form.qualifications.help_text }}</label>
             {% if form.qualifications.errors %}{% include 'materialize/form/field_errors.html' %}{% endif %}


### PR DESCRIPTION
If you make an application and get a validation error in the reference form, the data for the cover letter and qualifications are blank which means you submit an empty application. 

The displayed value still defaults to the initial value since you can view your application after you have submitted it and then the data is stored in form.initial.