### PR TITLE
Fix so that default logo is showed correctly

### DIFF
--- a/src/involvement/templates/involvement/open_positions.html
+++ b/src/involvement/templates/involvement/open_positions.html
@@ -9,8 +9,11 @@
         {% for pos in positions|dictsort:'recruitment_end' %}
             <li>
                 <div class="collapsible-header">
-                    {% if pos.role.team_logo is not None %}{% image pos.role.team_logo fill-45x45 as logo %}{% endif %}
-                    <img class="circle" src="{% if logo %}{{ logo.url }}{% else %}{% static 'images/bocken.svg' %}{% endif %}">
+                    {% if pos.role.team_logo is not None %}
+                        {% image pos.role.team_logo fill-45x45 class=circle%}
+                    {% else %}
+                        <img class="circle" src="{% static 'images/bocken.svg' %}">
+                    {% endif %}
                     <div class="header-text">
                         <h3>{{ pos }}</h3>
                         <div class="team">


### PR DESCRIPTION
When viewing all open positions on apply, if a team does not have a logo the utn logo should be used by default. However, this bug caused positions where teams don't have a logo to use the logo of the position before it. The utn logo is now showed correctly by default