### PR TITLE
SSN validator can now handle T numbers

### DIFF
--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+from utils.validators import SSNValidator
+from django.core.exceptions import ValidationError
+
+
+class SSNValidatorTests(TestCase):
+    ssn_validator = SSNValidator()
+
+    def ssn_is_valid(self, ssn):
+        try:
+            self.ssn_validator(ssn)
+            return True
+        except ValidationError:
+            return False
+
+    def test_long_format_with_dash(self):
+        self.assertTrue(
+            self.ssn_is_valid("19330524-8585"),
+            "Valid SSN format failed"
+        )
+        self.assertTrue(
+            self.ssn_is_valid("19330524-T585"),
+            "Valid SSN format with T failed"
+        )
+
+    def test_long_format_with_no_dash(self):
+        self.assertTrue(
+            self.ssn_is_valid("193305248585"),
+            "Valid SSN format failed"
+        )
+        self.assertTrue(
+            self.ssn_is_valid("19330524T585"),
+            "Valid SSN format with T failed"
+        )
+
+    def test_short_format_with_dash(self):
+        self.assertTrue(
+            self.ssn_is_valid("330524-8585"),
+            "Valid SSN format failed"
+        )
+        self.assertTrue(
+            self.ssn_is_valid("330524-T585"),
+            "Valid SSN format with T failed"
+        )
+
+    def test_short_format_with_no_dash(self):
+        self.assertTrue(
+            self.ssn_is_valid("3305248585"),
+            "Valid SSN format failed"
+        )
+        self.assertTrue(
+            self.ssn_is_valid("330524T585"),
+            "Valid SSN format with T failed"
+        )

--- a/src/utils/tests.py
+++ b/src/utils/tests.py
@@ -4,11 +4,9 @@ from django.core.exceptions import ValidationError
 
 
 class SSNValidatorTests(TestCase):
-    ssn_validator = SSNValidator()
-
     def ssn_is_valid(self, ssn):
         try:
-            self.ssn_validator(ssn)
+            SSNValidator()(ssn)
             return True
         except ValidationError:
             return False

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -6,10 +6,10 @@ class SSNValidator(validators.RegexValidator):
     def __init__(self):
         super(SSNValidator, self).__init__(
             # This regex makes sure that the year is either 1900 or 2000
-            regex=r'^[1-2][0|9][0-9]{2}[0-1][0-9][0-3][0-9][-][0-9]{4}$|'  # noqa: E501, YYYYMMDD-XXXX
-                  r'^[1-2][0|9][0-9]{2}[0-1][0-9][0-3][0-9][0-9]{4}$|'  # noqa: E501, YYYYMMDDXXXX
-                  r'^[0|9][0-9]{1}[0-1][0-9][0-3][0-9][-][0-9]{4}$|'  # noqa: E501, YYMMDD-XXXX
-                  r'^[0|9][0-9]{1}[0-1][0-9][0-3][0-9][0-9]{4}$',  # noqa: E501, YYMMDDXXXX
+            regex=r'^[1-2][0|9][0-9]{2}[0-1][0-9][0-3][0-9][-](T|t|[0-9])[0-9]{3}$|'  # noqa: E501, YYYYMMDD-XXXX
+                  r'^[1-2][0|9][0-9]{2}[0-1][0-9][0-3][0-9](T|t|[0-9])[0-9]{3}$|'  # noqa: E501, YYYYMMDDXXXX
+                  r'^[0|9][0-9]{1}[0-1][0-9][0-3][0-9][-](T|t|[0-9])[0-9]{3}$|'  # noqa: E501, YYMMDD-XXXX
+                  r'^[0|9][0-9]{1}[0-1][0-9][0-3][0-9](T|t|[0-9])[0-9]{3}$',  # noqa: E501, YYMMDDXXXX
             message=_(
                 'Use the format YYYYMMDD-XXXX, YYMMDD-XXXX, \
                 YYYYMMDDXXXX, YYMMDDXXXX for your ssn.'

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -3,13 +3,24 @@ from django.utils.translation import ugettext_lazy as _
 
 
 class SSNValidator(validators.RegexValidator):
+    century = r'[1-2][0|9]'  # YY-- Only allows 19-- and 20--
+    decade = r'[0-9]{2}'  # --YY
+    month = r'[0-1][0-9]'
+    day = r'[0-3][0-9]'
+    last_four = r'(T|t|[0-9])[0-9]{3}'  # Allows T-number SSN
+
     def __init__(self):
+        regex_pattern = \
+            r'^(' + self.century + r')?' + \
+            self.decade + \
+            self.month + \
+            self.day + \
+            r'(-|\+)?' + \
+            self.last_four + \
+            r'$'
+
         super(SSNValidator, self).__init__(
-            # This regex makes sure that the year is either 1900 or 2000
-            regex=r'^[1-2][0|9][0-9]{2}[0-1][0-9][0-3][0-9][-](T|t|[0-9])[0-9]{3}$|'  # noqa: E501, YYYYMMDD-XXXX
-                  r'^[1-2][0|9][0-9]{2}[0-1][0-9][0-3][0-9](T|t|[0-9])[0-9]{3}$|'  # noqa: E501, YYYYMMDDXXXX
-                  r'^[0|9][0-9]{1}[0-1][0-9][0-3][0-9][-](T|t|[0-9])[0-9]{3}$|'  # noqa: E501, YYMMDD-XXXX
-                  r'^[0|9][0-9]{1}[0-1][0-9][0-3][0-9](T|t|[0-9])[0-9]{3}$',  # noqa: E501, YYMMDDXXXX
+            regex=regex_pattern,
             message=_(
                 'Use the format YYYYMMDD-XXXX, YYMMDD-XXXX, \
                 YYYYMMDDXXXX, YYMMDDXXXX for your ssn.'


### PR DESCRIPTION
The ssn validator can now handle SSN with the letter T (T-number). I also added some test, made the code more readable and fixed so that people born before 1990 can register