### PR TITLE
Fix bug which caused long texts to disappear on banners

### DIFF
--- a/src/home/templates/home/banners.html
+++ b/src/home/templates/home/banners.html
@@ -24,8 +24,8 @@
     {% endif %}
     {% for banner in page.banners.all %}
         {% image banner.image height-700 as photo %}
-    	<div class="carousel-item content-center-v-sm {% if banner.image %} withImage {% endif %}">
-            <div>
+    	<div class="carousel-item {% if banner.image %} withImage {% endif %}">
+            <div class="center">
                 {% if banner.video %}
                     <video autoplay loop muted playsinline class="banner-video">
                         <source src="{{ banner.video.url }}"/>

--- a/src/moore/static/sass/partials/elements/_carousel.scss
+++ b/src/moore/static/sass/partials/elements/_carousel.scss
@@ -65,6 +65,13 @@ $controls-size: 150px;
   }
 
   .carousel-item {
+    .center{
+      justify-content: center;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      align-items: center;
+    }
     &.withImage {
       height: $banner-height;
       max-height: 100%;


### PR DESCRIPTION
When the description is too long on a banner, its content disappear on large screens and end up below the banner. This is now changed so that it uses flexbox instead

Before
![before](https://user-images.githubusercontent.com/19433606/74283563-5cd65a80-4d22-11ea-8e00-8de997348907.JPG)

After
![after](https://user-images.githubusercontent.com/19433606/74283569-62cc3b80-4d22-11ea-9fe2-dba79f1a8e45.JPG)

