### PR TITLE
fix image overlay help text

### DIFF
--- a/src/blocks/models.py
+++ b/src/blocks/models.py
@@ -119,11 +119,11 @@ class OverlayBlock(blocks.StructBlock):
     button = blocks.CharBlock(required=False)
     include_bottom_margin = blocks.BooleanBlock(
         required=False,
-        help_text=('margin-bot', _("Include margin under this block"))
+        help_text=_("Include margin under this block")
     )
     include_top_margin = blocks.BooleanBlock(
         required=False,
-        help_text=('margin-top', _("Include margin above this block"))
+        help_text=_("Include margin above this block")
     )
 
     class Meta:


### PR DESCRIPTION
### Description of the Change

Fixed faulty help text for the recently added image overlay margin options

### Applicable Issues

None
<!-- Enter any applicable issues here -->


<!--Please select the appropriate "topic category"/blue label -->