### PR TITLE
Uploaded files now get correct permissions

### DIFF
--- a/src/moore/settings/base.py
+++ b/src/moore/settings/base.py
@@ -146,6 +146,8 @@ STATIC_URL = '/static/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
 
+FILE_UPLOAD_PERMISSIONS = 0o644
+
 # Compressor
 # https://django-compressor.readthedocs.io/en/latest/settings/
 


### PR DESCRIPTION
When media files were uploaded they received the permission 600. On development this works because you run the server as your local user. However, in production we use nginx which runs with the user www-data and we run a socket that runs the moore instance with the user moore. All files are owned by the user moore and the group www-data. But since permissions were set to 600, www-data had no permissions to get the videos and therefor nginx could not serve those files. This is solved by setting the permissions of uploaded files to 644, giving nginx read access to all uploaded files