### PR TITLE
exposed wagtail api

### DIFF
--- a/src/home/models/home_page.py
+++ b/src/home/models/home_page.py
@@ -9,6 +9,7 @@ from wagtail.core.blocks import RawHTMLBlock
 from blocks.models import WAGTAIL_STATIC_BLOCKTYPES
 from news.models import LatestNewsBlock
 from utils.translation import TranslatedField
+from wagtail.api import APIField
 
 
 class HomePage(Page):
@@ -59,3 +60,9 @@ class HomePage(Page):
         ObjectList(Page.promote_panels, heading=_('Promote')),
         ObjectList(custom_settings_panel, heading=_('Settings')),
     ])
+
+    api_fields = [
+        APIField('title_sv'),
+        APIField('body_en'),
+        APIField('body_sv'),
+    ]

--- a/src/home/models/web_page.py
+++ b/src/home/models/web_page.py
@@ -11,6 +11,7 @@ from google.models import GoogleFormBlock, GoogleDriveBlock, \
     GoogleCalendarBlock
 from news.models import LatestNewsBlock
 from utils.translation import TranslatedField
+from wagtail.api import APIField
 
 
 class WebPage(Page):
@@ -58,3 +59,9 @@ class WebPage(Page):
         ObjectList(Page.promote_panels, heading=_('Promote')),
         ObjectList(Page.settings_panels, heading=_('Settings')),
     ])
+
+    api_fields = [
+        APIField('title_sv'),
+        APIField('body_en'),
+        APIField('body_sv'),
+    ]

--- a/src/moore/api.py
+++ b/src/moore/api.py
@@ -1,0 +1,9 @@
+from wagtail.api.v2.endpoints import PagesAPIEndpoint
+from wagtail.images.api.v2.endpoints import ImagesAPIEndpoint
+from wagtail.api.v2.router import WagtailAPIRouter
+from wagtail.documents.api.v2.endpoints import DocumentsAPIEndpoint
+
+api_router = WagtailAPIRouter('wagtailapi')
+api_router.register_endpoint('pages', PagesAPIEndpoint)
+api_router.register_endpoint('images', ImagesAPIEndpoint)
+api_router.register_endpoint('documents', DocumentsAPIEndpoint)

--- a/src/moore/settings/base.py
+++ b/src/moore/settings/base.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     'wagtail.contrib.settings',
     'wagtail.contrib.modeladmin',
     "wagtail.contrib.routable_page",
+    'wagtail.api.v2',
     'wagtailmedia',
 
     'compressor',

--- a/src/moore/urls.py
+++ b/src/moore/urls.py
@@ -8,7 +8,13 @@ from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
+from .api import api_router
+
 urlpatterns = [
+
+    # Needs to be imported before wagtail urls
+    url(r'^api/', api_router.urls),
+
     # Needs to be imported before wagtail admin
     url(r'', include('involvement.urls')),
 


### PR DESCRIPTION
### Description of the Change

Adds the built in wagtail json api. We can now query the web content as json and use wagtail as a CMS, which Forskå plans to do for it's app.
### Applicable Issues

<!-- Enter any applicable issues here -->


<!--Please select the appropriate "topic category"/blue label -->