### PR TITLE
Change default full width to false

### DIFF
--- a/src/home/migrations/0035_manual_sections_data.py
+++ b/src/home/migrations/0035_manual_sections_data.py
@@ -12,7 +12,7 @@ def body_to_section(stream_field):
         'type': 'section',
         'value': {
             'padding': "S",
-            'full_width': True,
+            'full_width': False,
             'body': stream_field.stream_data,
         }
     }
@@ -42,7 +42,7 @@ def apply_to_all_pages(apps, mapper):
     for obj in chain(hps, wps):
         obj.body_en = mapper(obj.body_en)
         obj.body_sv = mapper(obj.body_sv)
-        obj.save();
+        obj.save()
 
 def forwards(apps, schema_editor):
     apply_to_all_pages(apps, body_to_section)


### PR DESCRIPTION
Most of the current pages hosted on moore are built with the container class already in place. This makes a lot of pages look different and weird compared to what they used to look like. I have therefor changed the full width to be set to false instead