### PR TITLE
Fixed section migration so that html and news blocks are kept

### DIFF
--- a/src/home/migrations/0035_manual_sections_data.py
+++ b/src/home/migrations/0035_manual_sections_data.py
@@ -5,18 +5,24 @@ from itertools import chain
 from django.core.serializers.json import DjangoJSONEncoder
 from json import dumps
 from wagtail.core.blocks.stream_block import StreamValue
+from utils.data_migrations import block_filter
 
+import copy
 
 def body_to_section(stream_field):
+
+    page_blocks = block_filter(copy.deepcopy(stream_field.stream_data),
+                               lambda block: block['type'] == 'html' or block['type'] == 'news')
     section = {
         'type': 'section',
         'value': {
             'padding': "S",
             'full_width': True,
-            'body': stream_field.stream_data,
+            'body': block_filter(copy.deepcopy(stream_field.stream_data),
+                                 lambda block: block['type'] != 'html' and block['type'] != 'news')
         }
     }
-    raw_text = dumps([section], cls=DjangoJSONEncoder)
+    raw_text = dumps([section] + page_blocks, cls=DjangoJSONEncoder)
     stream_block = stream_field.stream_block
     return StreamValue(stream_block, [], is_lazy=True, raw_text=raw_text)
     

--- a/src/utils/data_migrations.py
+++ b/src/utils/data_migrations.py
@@ -30,6 +30,37 @@ def block_filter_map(block, block_type, mapper_func):
     return block
 
 
+""" 
+Recursively apply a filter operation on a block by traversing it
+and its children, and calling the predicate_func on each block. Only
+the blocks that make predicate_func return true are returned back, the
+others have their values cleared. Important: Does not deep copy by
+itself. Make sure to perform a deep copy beforehand!
+
+:param block: The block to apply the filter-map operation on
+:param predicate_func: Function that decides wether or not the block 
+is filtered
+:return: Returns a block hierarchy only containing the passing blocks.
+"""
+
+def block_filter(block, predicate_func):
+    if isinstance(block, list):
+        for i in range(len(block)):
+            block[i] = block_filter(block[i], predicate_func)
+    elif isinstance(block, dict):
+        if 'type' in block:
+            # This is a proper block
+            if predicate_func(block):
+                for k, v in block.items():
+                    block[k] = block_filter(v, predicate_func)
+            else:
+                return {'type': block['type'], 'value': {}}
+
+    # int or string or something, just return untouched
+    return block
+
+
+
 """
 Recursively apply a filter-map operation on a stream field,
 replacing every block or sub-block with the same type as block_type

--- a/src/utils/data_migrations.py
+++ b/src/utils/data_migrations.py
@@ -30,7 +30,7 @@ def block_filter_map(block, block_type, mapper_func):
     return block
 
 
-""" 
+"""
 Recursively apply a filter operation on a block by traversing it
 and its children, and calling the predicate_func on each block. Only
 the blocks that make predicate_func return true are returned back, the
@@ -38,10 +38,11 @@ others have their values cleared. Important: Does not deep copy by
 itself. Make sure to perform a deep copy beforehand!
 
 :param block: The block to apply the filter-map operation on
-:param predicate_func: Function that decides wether or not the block 
+:param predicate_func: Function that decides wether or not the block
 is filtered
 :return: Returns a block hierarchy only containing the passing blocks.
 """
+
 
 def block_filter(block, predicate_func):
     if isinstance(block, list):
@@ -58,7 +59,6 @@ def block_filter(block, predicate_func):
 
     # int or string or something, just return untouched
     return block
-
 
 
 """


### PR DESCRIPTION
### Description of the Change
This fixes an issue where the section-migration deleted html (and other page-level blocks) when applied. Hopefully balkå's page will stay intact now.

Also adds another recursive block_filter function to the data_migrations utility module that makes it easier to isolate specific blocks in a hierarchy.

<!--Please select the appropriate "topic category"/blue label -->