### PR TITLE
Remove facebook_app_id

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -6,7 +6,6 @@
 
 # export GOOGLE_API_KEY=
 # export INSTAGRAM_ACCESS_TOKEN=
-# export FACEBOOK_APP_ID=
 
 # Database info
 # export DJANGO_DB_NAME=

--- a/src/moore/settings/dev.py
+++ b/src/moore/settings/dev.py
@@ -72,9 +72,6 @@ GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY')
 # Instagram API
 INSTAGRAM_ACCESS_TOKEN = os.environ.get('INSTAGRAM_ACCESS_TOKEN')
 
-# Facebook API
-FACEBOOK_APP_ID = os.environ.get('FACEBOOK_APP_ID')
-
 try:
     from .local import *
 except ImportError:

--- a/src/moore/settings/production.py
+++ b/src/moore/settings/production.py
@@ -119,9 +119,6 @@ GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY')
 # Instagram API
 INSTAGRAM_ACCESS_TOKEN = os.environ.get('INSTAGRAM_ACCESS_TOKEN')
 
-# Facebook API
-FACEBOOK_APP_ID = os.environ.get('FACEBOOK_APP_ID')
-
 try:
     from .local import *
 except ImportError:

--- a/src/moore/settings/staging.py
+++ b/src/moore/settings/staging.py
@@ -56,8 +56,6 @@ GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY')
 # Instagram API
 INSTAGRAM_ACCESS_TOKEN = os.environ.get('INSTAGRAM_ACCESS_TOKEN')
 
-# Facebook API
-FACEBOOK_APP_ID = os.environ.get('FACEBOOK_APP_ID')
 
 try:
     from .local import *


### PR DESCRIPTION
Facebook_app_id is no longer used since public facebook pages can be accessed by anyone