### PR TITLE
Remove whitespace that exists in application form

### DIFF
--- a/src/involvement/templates/involvement/application_form.html
+++ b/src/involvement/templates/involvement/application_form.html
@@ -51,6 +51,7 @@
         <legend><i class="material-icons">assignment_ind</i> {{ form.cover_letter.label|title }}</legend>
 
         <div class="input-field">
+            {% spaceless %}
             <textarea
                 id="{{ form.cover_letter.auto_id }}"
                 name="{{ form.cover_letter.name }}"
@@ -61,6 +62,7 @@
             </textarea>
             <label for="{{ form.cover_letter.auto_id }}">{{ form.cover_letter.help_text }}</label>
             {% if form.cover_letter.errors %}{% include 'materialize/form/field_errors.html' %}{% endif %}
+            {% endspaceless %}
         </div>
     </fieldset>
 
@@ -68,6 +70,7 @@
         <legend><i class="material-icons">assignment</i> {{ form.qualifications.label|title }}</legend>
 
         <div class="input-field">
+            {% spaceless %}
             <textarea
                 id="{{ form.qualifications.auto_id }}"
                 name="{{ form.qualifications.name }}"
@@ -78,6 +81,7 @@
             </textarea>
             <label for="{{ form.qualifications.auto_id }}">{{ form.qualifications.help_text }}</label>
             {% if form.qualifications.errors %}{% include 'materialize/form/field_errors.html' %}{% endif %}
+            {% endspaceless %}
         </div>
     </fieldset>
 


### PR DESCRIPTION
In the application form, some spaces sneek in at the start of the application text which makes the application look weird. By using the spaceless tag it gets remvoed