### PR TITLE
URL changed from dev to utn.se

### DIFF
--- a/src/moore/settings/production.py
+++ b/src/moore/settings/production.py
@@ -43,7 +43,7 @@ DATABASES = {
 # Base URL to use when referring to full URLs within the Wagtail admin
 # backend - e.g. in notification emails. Don't include '/admin' or a
 # trailing slash
-BASE_URL = 'https://dev.utn.se'
+BASE_URL = 'https://utn.se'
 
 ALLOWED_HOSTS = ['.utn.se', '.utnarm.se']
 


### PR DESCRIPTION
### Description of the Change

There is a bug with links leading to dev.utn.se. This PR solved that. 

### Applicable Issues

<!-- Enter any applicable issues here -->


<!--Please select the appropriate "topic category"/blue label -->