### PR TITLE
rebuild create and edit users templates

### DIFF
--- a/src/members/templates/wagtailusers/users/create.html
+++ b/src/members/templates/wagtailusers/users/create.html
@@ -1,63 +1,26 @@
-{% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags %}
-{% load i18n %}
-{% block titletag %}{% trans "Add user" %}{% endblock %}
-{% block content %}
-
-    {% trans "Add user" as add_user_str %}
-    {% include "wagtailadmin/shared/header.html" with title=add_user_str merged=1 tabbed=1 icon="user" %}
-
-    <ul class="tab-nav merged">
-        <li class="active"><a href="#account">{% trans "Account" %}</a></li>
-        <li><a href="#roles">{% trans "Roles" %}</a></li>
-    </ul>
-
-    <form action="{% url 'wagtailusers_users:add' %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
-        <div class="tab-content">
-            {% csrf_token %}
-            <section id="account" class="active nice-padding">
-                <ul class="fields">
-                    {% block fields %}
-                        {% if form.separate_username_field %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.username_field %}
-                        {% endif %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.email %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.phone_number %}
-                        {% block extra_fields %}
-							{% include "wagtailadmin/shared/field_as_li.html" with field=form.person_number %}
-							{% include "wagtailadmin/shared/field_as_li.html" with field=form.registration_year %}
-							{% include "wagtailadmin/shared/field_as_li.html" with field=form.study %}
-							{% include "wagtailadmin/shared/field_as_li.html" with field=form.section %}
-						{% endblock extra_fields %}
-                        {% if form.password1 %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
-                        {% endif %}
-                        {% if form.password2 %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
-                        {% endif %}
-                    {% endblock fields %}
-
-                    <li><a href="#roles" class="button lowpriority tab-toggle icon icon-arrow-right-after">{% trans "Roles" %}</a></li>
-                </ul>
-            </section>
-            <section id="roles" class="nice-padding">
-                <ul class="fields">
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
-                    <li><button class="button">{% trans "Add user" %}</button></li>
-                </ul>
-            </section>
-        </div>
-    </form>
-{% endblock %}
-
+{% extends "wagtailusers/users/create.html" %}
+{% block fields %}
+    {% if form.separate_username_field %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.username_field %}
+    {% endif %}
+    {% include "wagtailadmin/shared/field_as_li.html" with field=form.email %}
+    {% include "wagtailadmin/shared/field_as_li.html" with field=form.phone_number %}
+    {% block extra_fields %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.person_number %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.registration_year %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.study %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.section %}
+    {% endblock extra_fields %}
+    {% if form.password1 %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
+    {% endif %}
+    {% if form.password2 %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
+    {% endif %}
+{% endblock fields %}
 {% block extra_head %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ form.media.css }}
 {% endblock %}
-{% block extra_js %}
-    {{ block.super }}
-    {% include "wagtailadmin/pages/_editor_js.html" %}
-    {{ form.media.js }}
-{% endblock %}
+

--- a/src/members/templates/wagtailusers/users/edit.html
+++ b/src/members/templates/wagtailusers/users/edit.html
@@ -1,82 +1,30 @@
-{% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags %}
-{% load i18n %}
-{% block titletag %}{% trans "Editing" %} {{ user.get_username}}{% endblock %}
-{% block content %}
-
-    {% trans "Editing" as editing_str %}
-    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=user.get_username merged=1 tabbed=1 icon="user" %}
-
-    <ul class="tab-nav merged">
-        <li class="active"><a href="#account">{% trans "Account" %}</a></li>
-        <li><a href="#roles">{% trans "Roles" %}</a></li>
-    </ul>
-
-    <form action="{% url 'wagtailusers_users:edit' user.pk %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
-        <div class="tab-content">
-            {% csrf_token %}
-
-            <section id="account" class="active nice-padding">
-                <ul class="fields">
-                    {% block fields %}
-                        {% if form.separate_username_field %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.username_field %}
-						{% endif %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.name %}
-							{% include "wagtailadmin/shared/field_as_li.html" with field=form.email %}
-						{% block extra_fields %}
-							{% include "wagtailadmin/shared/field_as_li.html" with field=form.person_number %}
-							{% include "wagtailadmin/shared/field_as_li.html" with field=form.status %}
-							{% include "wagtailadmin/shared/field_as_li.html" with field=form.phone_number %}
-							{% include "wagtailadmin/shared/field_as_li.html" with field=form.registration_year %}
-							{% include "wagtailadmin/shared/field_as_li.html" with field=form.study %}
-							{% include "wagtailadmin/shared/field_as_li.html" with field=form.section %}
-						{% endblock extra_fields %}
-                        {% if form.password1 %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
-                        {% endif %}
-                        {% if form.password2 %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
-                        {% endif %}
-                        {% if form.is_active %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_active %}
-                        {% endif %}
-
-                    {% endblock fields %}
-                    <li>
-                        <input type="submit" value="{% trans 'Save' %}" class="button" />
-                        {% if can_delete %}
-                            <a href="{% url 'wagtailusers_users:delete' user.pk %}" class="button button-secondary no">{% trans "Delete user" %}</a>
-                        {% endif %}
-                    </li>
-                </ul>
-            </section>
-            <section id="roles" class="nice-padding">
-                <ul class="fields">
-                    {% if form.is_superuser %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
-                    {% endif %}
-
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
-                    <li>
-                        <input type="submit" value="{% trans 'Save' %}" class="button" />
-                        {% if can_delete %}
-                            <a href="{% url 'wagtailusers_users:delete' user.pk %}" class="button button-secondary no">{% trans "Delete user" %}</a>
-                        {% endif %}
-                    </li>
-                </ul>
-            </section>
-        </div>
-    </form>
-{% endblock %}
-
+{% extends "wagtailusers/users/edit.html" %}
+{% block fields %}
+    {% if form.separate_username_field %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.username_field %}
+    {% endif %}
+    {% include "wagtailadmin/shared/field_as_li.html" with field=form.name %}
+    {% include "wagtailadmin/shared/field_as_li.html" with field=form.email %}
+    {% block extra_fields %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.person_number %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.status %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.phone_number %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.registration_year %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.study %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.section %}
+    {% endblock extra_fields %}
+    {% if form.password1 %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
+    {% endif %}
+    {% if form.password2 %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
+    {% endif %}
+    {% if form.is_active %}
+        {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_active %}
+    {% endif %}
+{% endblock fields %}
 {% block extra_head %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ form.media.css }}
-{% endblock %}
-{% block extra_js %}
-    {{ block.super }}
-    {% include "wagtailadmin/pages/_editor_js.html" %}
-    {{ form.media.js }}
 {% endblock %}


### PR DESCRIPTION
The roles tab when adding and editing users does nothing when clicked. The reason for this is that wagtail changed how those tabs are rendered and we had overwritten that new changes with our templates.

Our templates has the following line `<ul class="tab-nav merged">`. In wagtails new templates it should be `<ul class="tab-nav merged" data-tab-nav>`

What I noticed was that the two templates were directly copied from wagtails built-in templates when they were created. I rebuild them to extend them instead and then just keep the changes we need to prevent similar issues from happening again.