### PR TITLE
urlize links in role descriptions and avoid long links to break the page

### DIFF
--- a/src/involvement/templates/involvement/position.html
+++ b/src/involvement/templates/involvement/position.html
@@ -29,12 +29,12 @@
                 </div>
             </div>
 
-            <div class="col s12 m8 pull-m4">
+            <div class="col s12 m8 pull-m4" style="overflow-wrap:anywhere">
                 <h1>{{ position }}</h1>
                 <span class="deadline" style="color: {{ position.recruitment_end|date_color }};">{% trans 'deadline'|capfirst %}: {{ position.recruitment_end }}</span>
 
                 <h2>{% trans 'role description'|title %}</h2>
-                <p>{% if position.role.description %}{{ position.role.description|linebreaks }}{% else %}{% trans 'No role description is available at this time. For more information about this position, please get in contact with us.' %}{% endif %}</p>
+                <div>{% if position.role.description %}{{ position.role.description|linebreaks|urlize }}{% else %}{% trans 'No role description is available at this time. For more information about this position, please get in contact with us.' %}{% endif %}</div>
 
                 {% if position.comment %}
                     <h2>{% trans 'comments for this year'|title %}</h2>


### PR DESCRIPTION
I added the urlize tag to the role description on the page where you apply for a position. This makes any links in the role description into clickable links. I also added an overflow wrap so that long links to google drive no longer stretch outside the website, but are instead wrapped around. This is mostly a problem on mobile devices

# Before
![image](https://user-images.githubusercontent.com/19433606/154851412-a078c1f4-8664-4a26-b20c-31b1983eab54.png)

# After
![image](https://user-images.githubusercontent.com/19433606/154851445-8d1bae73-c0ac-46dc-9214-c2639808f0d4.png)
