### PR TITLE
remove login notice

### DIFF
--- a/src/members/templates/registration/login.html
+++ b/src/members/templates/registration/login.html
@@ -12,8 +12,6 @@
     <div class="message error">{{ error }}</div>
 {% endfor %}
 
-<div class="registration-warning">{% blocktrans %}If you had an UTN-account before the 23rd of December 2019, you must create a new one because of an update of our database.{% endblocktrans %}</div>
-
 {% if next %}
     {% if user.is_authenticated %}
         <div class="message warning">{% blocktrans %}Your account doesn't have access to this page. To proceed, please login with an account that has access.{% endblocktrans %}</div>

--- a/src/moore/static/sass/partials/pages/_all.scss
+++ b/src/moore/static/sass/partials/pages/_all.scss
@@ -5,4 +5,3 @@
 @import "search";
 @import "contact";
 @import "google_calendar";
-@import "login";

--- a/src/moore/static/sass/partials/pages/_login.scss
+++ b/src/moore/static/sass/partials/pages/_login.scss
@@ -1,7 +1,0 @@
-.registration-warning {
-    background: $yellow-color;
-    color: $secondary-color;
-    padding: 20px;
-    margin-bottom: 40px;
-    border-radius: 12px;
-}


### PR DESCRIPTION
I have removed the login notice about accounts created before 2019 that is on the login page since it is no longer needed 4 years later

Closes #712 