### PR TITLE
Update django to 3.2.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 
-Django[argon2]==3.2.3
+Django[argon2]==3.2.18
 wagtail==2.13
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 
-Django[argon2]==3.2.18
+Django[argon2]==3.2.17
 wagtail==2.13
 
 


### PR DESCRIPTION
I see that there are a lot of security issues regarding the current version. Many of these are critical and some are SQL injections which are not a good thing to have in production. Upgrading to django 4 though is a bit of a process so in the meanwhile it could be a good idea to update to 3.2.17 which patches all these security issues.

I suggest getting this out into production ASAP as we don't want hackers to be able to access all our data in project moore