### PR TITLE
update wagtail to 2.13.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
 Django[argon2]==3.2.3
-wagtail==2.13
+wagtail==2.13.5
 
 
 # External Libraries


### PR DESCRIPTION
There is a security issue for wagtail. Since updating to 2.16 is a bit of a progress, a intermediate update to 2.13.5 will patch those security issues