### PR TITLE
Bug fix. Removed unnecessary text next to the title in webpage

### DIFF
--- a/src/moore/templates/page.html
+++ b/src/moore/templates/page.html
@@ -5,14 +5,6 @@
     <div class="content-title">
         <div class="container">
             <h1>{% firstof page.translated_title page.title %}</h1>
-            <ul class="breadcrumbs">
-                {% for page in self.get_ancestors %}
-                    {% if page.is_root == False %}
-                        <li><a href="{% pageurl page %}">{% firstof page.translated_title page.title %}</a> <i class="material-icons">keyboard_arrow_right</i></li>
-                    {% endif %}
-                {% endfor %}
-                <li class="active">{% firstof page.translated_title page.title %}</li>
-            </ul>
         </div>
     </div>
     {% block content %}{% endblock %}


### PR DESCRIPTION
### Description of the Change

There was unnecessary text that showes next to the title in a web page. Removed that 

### Applicable Issues

Webpage Title