### PR TITLE
Fix/sorted section list 467

### DIFF
--- a/src/members/forms.py
+++ b/src/members/forms.py
@@ -348,7 +348,7 @@ class CustomUserEditForm(UserEditForm):
     )
     section = forms.ModelChoiceField(
         required=False,
-        queryset=Section.objects,
+        queryset=Section.objects.order_by('abbreviation'),
         label=_('Section'),
     )
     status = forms.ChoiceField(
@@ -412,7 +412,7 @@ class CustomUserCreationForm(UserCreationForm):
     )
     section = forms.ModelChoiceField(
         required=False,
-        queryset=Section.objects,
+        queryset=Section.objects.order_by('abbreviation'),
         label=_("Section"),
     )
 

--- a/src/members/urls.py
+++ b/src/members/urls.py
@@ -3,7 +3,7 @@ from django.urls import reverse_lazy
 from django.views.generic import CreateView
 
 from members import views
-from members.forms import RegistrationForm
+from members.forms import CustomUserCreationForm
 
 urlpatterns = [
     re_path(r'^profile/$', views.ProfileView.as_view(), name='profile'),
@@ -14,7 +14,7 @@ urlpatterns = [
     ),
     re_path('^register/', CreateView.as_view(
         template_name='members/register.html',
-        form_class=RegistrationForm,
+        form_class=CustomUserCreationForm,
         success_url=reverse_lazy('login'),
     ), name='register'),
 


### PR DESCRIPTION
### Description of the Change

Changed the frontend register page to use `CustomUserCreationForm` from members.forms instead of `RegistrationForm`.
Also changed _CustomUserCreationForm_ to provided a sorted section list (sorted by the section abbreviation) by using ```Section.objects.order_by('abbreviation')``` instead of ```Section.objects```  in the file `src/members/forms.py`.

### Applicable Issues
fixes #467 and makes the sections ordered by their abbreviations


<!--Please select the appropriate "topic category"/blue label -->