### PR TITLE
Fix/sorted section list 467

### DIFF
--- a/src/members/forms.py
+++ b/src/members/forms.py
@@ -24,6 +24,11 @@ User = get_user_model()
 
 
 class MemberForm(forms.ModelForm):
+    section = forms.ModelChoiceField(
+        required=False,
+        queryset=Section.objects.order_by('abbreviation'),
+        label=_('Section'),
+    )
     person_number = PersonNumberField(
         label=_('Person number'),
         help_text=_('Person number using the YYYYMMDD-XXXX format.'),
@@ -81,6 +86,12 @@ class MemberForm(forms.ModelForm):
 
 
 class RegistrationForm(MemberForm, auth.UserCreationForm):
+    section = forms.ModelChoiceField(
+        required=False,
+        queryset=Section.objects.order_by('abbreviation'),
+        label=_('Section'),
+    )
+
     class Meta:
         model = Member
         fields = ['username', 'email', 'phone_number', 'section']
@@ -216,6 +227,12 @@ class UserForm(wagtail.UsernameForm):
         widget=forms.PasswordInput,
         help_text=_("Enter the same password as above, for verification."))
 
+    section = forms.ModelChoiceField(
+        required=False,
+        queryset=Section.objects.order_by('abbreviation'),
+        label=_('Section'),
+    )
+
     is_superuser = forms.BooleanField(
         label=_("Administrator"), required=False,
         help_text=_('Administrators have full access to manage any object '
@@ -304,6 +321,11 @@ class UserForm(wagtail.UsernameForm):
 
 class UserEditForm(UserForm):
     password_required = False
+    section = forms.ModelChoiceField(
+        required=False,
+        queryset=Section.objects.order_by('abbreviation'),
+        label=_('Section'),
+    )
 
     def __init__(self, *args, **kwargs):
         kwargs.pop('editing_self', False)

--- a/src/members/forms.py
+++ b/src/members/forms.py
@@ -348,7 +348,7 @@ class CustomUserEditForm(UserEditForm):
     )
     section = forms.ModelChoiceField(
         required=False,
-        queryset=Section.objects,
+        queryset=Section.objects.order_by('abbreviation'),
         label=_('Section'),
     )
     status = forms.ChoiceField(
@@ -412,7 +412,7 @@ class CustomUserCreationForm(UserCreationForm):
     )
     section = forms.ModelChoiceField(
         required=False,
-        queryset=Section.objects,
+        queryset=Section.objects.order_by('abbreviation'),
         label=_("Section"),
     )
 

--- a/src/members/urls.py
+++ b/src/members/urls.py
@@ -3,7 +3,7 @@ from django.urls import reverse_lazy
 from django.views.generic import CreateView
 
 from members import views
-from members.forms import CustomUserCreationForm
+from members.forms import RegistrationForm
 
 urlpatterns = [
     re_path(r'^profile/$', views.ProfileView.as_view(), name='profile'),
@@ -14,7 +14,7 @@ urlpatterns = [
     ),
     re_path('^register/', CreateView.as_view(
         template_name='members/register.html',
-        form_class=CustomUserCreationForm,
+        form_class=RegistrationForm,
         success_url=reverse_lazy('login'),
     ), name='register'),
 

--- a/src/members/urls.py
+++ b/src/members/urls.py
@@ -3,7 +3,7 @@ from django.urls import reverse_lazy
 from django.views.generic import CreateView
 
 from members import views
-from members.forms import RegistrationForm
+from members.forms import CustomUserCreationForm
 
 urlpatterns = [
     re_path(r'^profile/$', views.ProfileView.as_view(), name='profile'),
@@ -14,7 +14,7 @@ urlpatterns = [
     ),
     re_path('^register/', CreateView.as_view(
         template_name='members/register.html',
-        form_class=RegistrationForm,
+        form_class=CustomUserCreationForm,
         success_url=reverse_lazy('login'),
     ), name='register'),
 


### PR DESCRIPTION
Description of the Change
Changed the frontend register page to use to use sorted version of the Section queryset by adding:
```python
section = forms.ModelChoiceField(
        required=False,
        queryset=Section.objects.order_by('abbreviation'),
        label=_('Section'),
)
```
Where `abbreviation` is the column we sort for.
This also fixes the problem when editing your section on your homepage.

Applicable Issues
fixes https://github.com/UTNkar/moore/issues/467 and makes the sections ordered by their abbreviations