### PR TITLE
Fixed number check on backend user creation #348

### DIFF
--- a/src/members/forms.py
+++ b/src/members/forms.py
@@ -351,10 +351,9 @@ class CustomUserEditForm(UserEditForm):
         help_text=_('Person number using the YYYYMMDD-XXXX format.'),
         required=False
     )
-    phone_number = forms.CharField(
-        required=True,
-        label=_('Phone number'),
-    )
+
+    phone_number = PhoneNumberField()
+
     email = forms.EmailField(
         required=True,
         label=_('Email'),
@@ -419,10 +418,7 @@ class CustomUserCreationForm(UserCreationForm):
         required=True,
         label=_('Email'),
     )
-    phone_number = forms.CharField(
-        required=True,
-        label=_('Phone number'),
-    )
+    phone_number = PhoneNumberField()
     registration_year = forms.CharField(
         required=False,
         label=_('Registration year'),


### PR DESCRIPTION
Description of the Change
Changed the backend user creation page to check format of phone number (the same way https://utn.se/accounts/register/ dose)

Applicable Issues
fixes #348 by checking the format of the phone number on the admin backend.