### PR TITLE
Add changes to activate cron job that deletes old applications 7 days after role appointment is done and saved

### DIFF
--- a/src/involvement/cron.py
+++ b/src/involvement/cron.py
@@ -72,8 +72,8 @@ def send_extension_emails():
 def remove_old_applications():
     old_applications = Application.objects.filter(
         position__recruitment_end__lte=date.today() - timedelta(days=7)
-    ).exclude(
-        status='appointed'
+    ).filter(
+        status='turned_down'
     )
 
     for app in old_applications:

--- a/src/involvement/forms/appointment_form.py
+++ b/src/involvement/forms/appointment_form.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from involvement.models import Application
 from utils.forms import AdvancedModelMultipleChoiceField
 from utils.melos_client import MelosClient
+from involvement import cron
 
 
 class AppointmentForm(forms.Form):
@@ -99,3 +100,4 @@ class AppointmentForm(forms.Form):
             if not created:
                 appl.status = 'appointed'
                 appl.save()
+        cron.remove_old_applications()


### PR DESCRIPTION
### Description of the Change

<!-- We must be able to understand the design of your change from this description. -->
Cron job that was supposed to delete old applications had no implementation. Changes done to call this cron job to delete old applications that were turned down, 7 days after a role has been appointed and saved.

### Applicable Issues

<!-- Enter any applicable issues here -->
Fixes issue #786 

<!--Please select the appropriate "topic category"/blue label -->
`feature`