### PR TITLE
Serve utn.se/admin at admin.utn.se

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@
 django_recaptcha==3.0.0
 Django[argon2]==3.2.17
 wagtail==2.16.2
+# Allows subdomains
+django-hosts==6.0
 
 # External Libraries
 requests==2.28.2

--- a/src/admin/urls.py
+++ b/src/admin/urls.py
@@ -5,14 +5,12 @@ from django.conf.urls import include, url
 from wagtail.admin import urls as wagtailadmin_urls
 
 from moore.urls import urlpatterns as base_urlpatterns
-from moore.urls_utils import insert_urls_before
 
 # Use the same `urlpatterns` as other domains as the base
 urlpatterns = base_urlpatterns.copy()
 
-# Insert `wagtailadmin_urls` before `wagtail_urls`
-urlpatterns = insert_urls_before(
-    urlpatterns,
-    before_name='wagtail_urls',
-    url=url(r'', include(wagtailadmin_urls))
+# Insert `wagtailadmin_urls` at appropriate level
+urlpatterns.insert(
+    len(urlpatterns) - 3,
+    url(r'', include(wagtailadmin_urls))
 )

--- a/src/admin/urls.py
+++ b/src/admin/urls.py
@@ -1,14 +1,7 @@
 
-# from wagtail.admin import urls as wagtailadmin_urls
-# from django.conf.urls import include, url
-
-# urlpatterns = [
-#     url(r'', include(wagtailadmin_urls)),
-# ]
-
-from django.contrib import admin
-from django.urls import path
+from wagtail.admin import urls as wagtailadmin_urls
+from django.urls import path, include
 
 urlpatterns = [
-    path('', admin.site.urls),
+    path(r'', include(wagtailadmin_urls)),
 ]

--- a/src/admin/urls.py
+++ b/src/admin/urls.py
@@ -1,0 +1,14 @@
+
+# from wagtail.admin import urls as wagtailadmin_urls
+# from django.conf.urls import include, url
+
+# urlpatterns = [
+#     url(r'', include(wagtailadmin_urls)),
+# ]
+
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path('', admin.site.urls),
+]

--- a/src/admin/urls.py
+++ b/src/admin/urls.py
@@ -1,7 +1,18 @@
+from __future__ import absolute_import, unicode_literals
 
+from django.conf.urls import include, url
+
+from wagtail.core import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
-from django.urls import path, include
+from moore.urls import urlpatterns as base_urlpatterns
 
-urlpatterns = [
-    path(r'', include(wagtailadmin_urls)),
-]
+# Use the same `urlpatterns` as other domains as the base
+urlpatterns = base_urlpatterns.copy()
+
+# Append `wagtailadmin_urls` before `wagtail_urls`
+for index, pattern in enumerate(urlpatterns):
+    if hasattr(pattern, 'url_patterns'):
+        if wagtail_urls.urlpatterns == pattern.url_patterns:
+            # Insert the new_pattern before the wagtail include
+            urlpatterns.insert(index, url(r'', include(wagtailadmin_urls)))
+            break

--- a/src/admin/urls.py
+++ b/src/admin/urls.py
@@ -2,17 +2,17 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
 
-from wagtail.core import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
+
 from moore.urls import urlpatterns as base_urlpatterns
+from moore.urls_utils import insert_urls_before
 
 # Use the same `urlpatterns` as other domains as the base
 urlpatterns = base_urlpatterns.copy()
 
-# Append `wagtailadmin_urls` before `wagtail_urls`
-for index, pattern in enumerate(urlpatterns):
-    if hasattr(pattern, 'url_patterns'):
-        if wagtail_urls.urlpatterns == pattern.url_patterns:
-            # Insert the new_pattern before the wagtail include
-            urlpatterns.insert(index, url(r'', include(wagtailadmin_urls)))
-            break
+# Insert `wagtailadmin_urls` before `wagtail_urls`
+urlpatterns = insert_urls_before(
+    urlpatterns,
+    before_name='wagtail_urls',
+    url=url(r'', include(wagtailadmin_urls))
+)

--- a/src/admin/views.py
+++ b/src/admin/views.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+from django_hosts.resolvers import reverse_host
+from django.http import HttpResponseRedirect
+
+
+def redirect_admin(request, path):
+    protocol = 'https' if request.is_secure() else 'http'
+    host = reverse_host(host='admin')
+    if getattr(settings, 'HOST_PORT', None):
+        host = f"{host}:{settings.HOST_PORT}"
+    return HttpResponseRedirect(f'{protocol}://{host}/{path}')

--- a/src/moore/settings/base.py
+++ b/src/moore/settings/base.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
     'captcha',
     'jsonschemaform',
     'django_select2',  # Custom select2 widget
+    'django_hosts',  # Subdomains for admin site
 
     'django.contrib.admin',  # Used for wagtail admin filters
     'django.contrib.auth',
@@ -79,6 +80,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'django_hosts.middleware.HostsRequestMiddleware',  # Needed django_hosts
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -89,6 +91,7 @@ MIDDLEWARE = [
     'django.middleware.locale.LocaleMiddleware',
 
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
+    'django_hosts.middleware.HostsResponseMiddleware',  # Needed django_hosts
 ]
 
 DATABASES = {
@@ -103,6 +106,8 @@ DATABASES = {
 }
 
 ROOT_URLCONF = 'moore.urls'
+ROOT_HOSTCONF = 'moore.settings.hosts'
+
 
 TEMPLATES = [
     {

--- a/src/moore/settings/base.py
+++ b/src/moore/settings/base.py
@@ -69,7 +69,7 @@ INSTALLED_APPS = [
     'captcha',
     'jsonschemaform',
     'django_select2',  # Custom select2 widget
-    'django_hosts',  # Subdomains for admin site
+    'django_hosts',  # Subdomain for admin site
 
     'django.contrib.admin',  # Used for wagtail admin filters
     'django.contrib.auth',
@@ -80,7 +80,8 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'django_hosts.middleware.HostsRequestMiddleware',  # Needed django_hosts
+    # Subdomain for admin site. Needed by django_hosts
+    'django_hosts.middleware.HostsRequestMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -91,7 +92,8 @@ MIDDLEWARE = [
     'django.middleware.locale.LocaleMiddleware',
 
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
-    'django_hosts.middleware.HostsResponseMiddleware',  # Needed django_hosts
+    # Subdomain for admin site. Needed by django_hosts
+    'django_hosts.middleware.HostsResponseMiddleware',
 ]
 
 DATABASES = {
@@ -106,7 +108,9 @@ DATABASES = {
 }
 
 ROOT_URLCONF = 'moore.urls'
+# Needed for django hosts, enables us to publish wagtail admin on subdomain.
 ROOT_HOSTCONF = 'moore.settings.hosts'
+DEFAULT_HOST = 'default'
 
 
 TEMPLATES = [

--- a/src/moore/settings/dev.py
+++ b/src/moore/settings/dev.py
@@ -51,7 +51,6 @@ elif 'DOCKER' in os.environ:
 # backend - e.g. in notification emails. Don't include '/admin' or a
 # trailing slash
 BASE_URL = 'http://localhost:8000'
-DEFAULT_HOST = 'www'
 
 ALLOWED_HOSTS = ['admin.localhost', 'localhost']
 # Email

--- a/src/moore/settings/dev.py
+++ b/src/moore/settings/dev.py
@@ -51,7 +51,9 @@ elif 'DOCKER' in os.environ:
 # backend - e.g. in notification emails. Don't include '/admin' or a
 # trailing slash
 BASE_URL = 'http://localhost:8000'
+DEFAULT_HOST = 'www'
 
+ALLOWED_HOSTS = ['admin.localhost', 'localhost']
 # Email
 # https://docs.djangoproject.com/en/1.10/ref/settings/#email-backend
 

--- a/src/moore/settings/dev.py
+++ b/src/moore/settings/dev.py
@@ -53,6 +53,8 @@ elif 'DOCKER' in os.environ:
 BASE_URL = 'http://localhost:8000'
 
 ALLOWED_HOSTS = ['admin.localhost', 'localhost']
+PARENT_HOST = 'localhost'
+HOST_PORT = '8000'
 # Email
 # https://docs.djangoproject.com/en/1.10/ref/settings/#email-backend
 

--- a/src/moore/settings/hosts.py
+++ b/src/moore/settings/hosts.py
@@ -3,6 +3,6 @@ from django.conf import settings
 
 host_patterns = patterns(
     '',
-    host(r'www', settings.ROOT_URLCONF, name='www'),
+    host(r'', settings.ROOT_URLCONF, name='default'),
     host(r'admin', 'admin.urls', name='admin'),
 )

--- a/src/moore/settings/hosts.py
+++ b/src/moore/settings/hosts.py
@@ -1,0 +1,8 @@
+from django_hosts import patterns, host
+from django.conf import settings
+
+host_patterns = patterns(
+    '',
+    host(r'www', settings.ROOT_URLCONF, name='www'),
+    host(r'admin', 'admin.urls', name='admin'),
+)

--- a/src/moore/settings/production.py
+++ b/src/moore/settings/production.py
@@ -40,6 +40,7 @@ sentry_sdk.init(
 BASE_URL = 'https://utn.se'
 
 ALLOWED_HOSTS = ['.utn.se', '.utnarm.se']
+PARENT_HOST = 'utn.se'
 
 # Email settings
 DEFAULT_FROM_EMAIL = 'info@utn.se'

--- a/src/moore/urls.py
+++ b/src/moore/urls.py
@@ -5,7 +5,6 @@ from django.conf.urls import include, url
 from django.urls import path, re_path
 
 from search import views as search_views
-# from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
@@ -18,7 +17,6 @@ urlpatterns = [
     # Needs to be imported before wagtail urls
     url(r'^api/', api_router.urls),
 
-    # Needs to be imported before wagtail admin
     url(r'', include('involvement.urls')),
     url(r'', include('events.urls')),
     path('member_check_api/', member_check_api, name='member_check_api'),

--- a/src/moore/urls.py
+++ b/src/moore/urls.py
@@ -47,7 +47,7 @@ urlpatterns = [
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in
     # the list:
-    url(r'', include((wagtail_urls, 'wagtail_urls'))),
+    url(r'', include(wagtail_urls)),
 ]
 
 if settings.DEBUG:

--- a/src/moore/urls.py
+++ b/src/moore/urls.py
@@ -2,19 +2,19 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 from django.conf.urls import include, url
-from django.urls import path
+from django.urls import path, re_path
 
 from search import views as search_views
-from wagtail.admin import urls as wagtailadmin_urls
+# from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 from .api import api_router
 
 from members.views import member_check_api
+from admin.views import redirect_admin
 
 urlpatterns = [
-
     # Needs to be imported before wagtail urls
     url(r'^api/', api_router.urls),
 
@@ -23,7 +23,8 @@ urlpatterns = [
     url(r'', include('events.urls')),
     path('member_check_api/', member_check_api, name='member_check_api'),
 
-    url(r'^admin/', include(wagtailadmin_urls)),
+    re_path(r'^admin/(?P<path>.*)$', redirect_admin),
+
     url(r'^documents/', include(wagtaildocs_urls)),
 
     url(r'^search/$', search_views.search, name='search'),

--- a/src/moore/urls_utils.py
+++ b/src/moore/urls_utils.py
@@ -1,22 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.urls.resolvers import URLResolver
-
-
-def insert_urls_before(urlpatterns: list, before_name: str, url: URLResolver):
-    for index, pattern in enumerate(urlpatterns):
-        # Insert before index if `name` or `app_name` matches
-        if hasattr(pattern, 'name'):
-            if pattern.name == before_name:
-                urlpatterns.insert(index, url)
-                break
-        elif hasattr(pattern, 'app_name'):
-            if pattern.app_name == before_name:
-                urlpatterns.insert(index, url)
-                break
-
-    return urlpatterns
-
 
 def delete_urls(urlpatterns: list, delete_name: str):
     for index, pattern in enumerate(urlpatterns):

--- a/src/moore/urls_utils.py
+++ b/src/moore/urls_utils.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.urls.resolvers import URLResolver
+
+
+def insert_urls_before(urlpatterns: list, before_name: str, url: URLResolver):
+    for index, pattern in enumerate(urlpatterns):
+        # Insert before index if `name` or `app_name` matches
+        if hasattr(pattern, 'name'):
+            if pattern.name == before_name:
+                urlpatterns.insert(index, url)
+                break
+        elif hasattr(pattern, 'app_name'):
+            if pattern.app_name == before_name:
+                urlpatterns.insert(index, url)
+                break
+
+    return urlpatterns
+
+
+def delete_urls(urlpatterns: list, delete_name: str):
+    for index, pattern in enumerate(urlpatterns):
+        if hasattr(pattern, 'name'):
+            if pattern.name == delete_name:
+                # Insert before index
+                urlpatterns.pop(index)
+                break
+
+    return urlpatterns


### PR DESCRIPTION
Proof of concept of mapping access to subdomain using `django-hosts`.
Currently mapped django default admin page to admin.localhost for development build only

### Description of the Change

Added `django-hosts` to allow for subdomain to be handeld by django.
Then create a admin "app" that contains a url.py that redirects to chosen admin page 

**This is just a proof of concept.**